### PR TITLE
Add example DAGs, Dockerfile, dbt profile.yml files needed for Docker and K8S operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dags/dbt/**/dbt_packages/**
 dags/dbt/**/.DS_Store
 dbt/**/*.log
 venv/
+.idea/

--- a/Dockerfile.postgres_profile_docker_k8s
+++ b/Dockerfile.postgres_profile_docker_k8s
@@ -1,0 +1,16 @@
+FROM python:3.9
+
+RUN pip install dbt-postgres==1.3.1 psycopg2==2.9.3 pytz
+
+ENV POSTGRES_DATABASE=postgres
+ENV POSTGRES_HOST=host.docker.internal
+ENV POSTGRES_PASSWORD=<postgres_password>
+ENV POSTGRES_PORT=5432
+ENV POSTGRES_SCHEMA=public
+ENV POSTGRES_USER=postgres
+
+RUN mkdir /root/.dbt
+COPY example_postgres_profile.yml /root/.dbt/profiles.yml
+
+COPY dags dags
+COPY postgres_profile_dbt_project.yml dags/dbt/jaffle_shop/dbt_project.yml

--- a/dags/jaffle_shop_docker.py
+++ b/dags/jaffle_shop_docker.py
@@ -1,0 +1,48 @@
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.utils.task_group import TaskGroup
+from pendulum import datetime
+
+from cosmos.providers.dbt.core.operators.docker import DbtRunOperationDockerOperator, DbtSeedDockerOperator
+
+
+# PATH within the Docker container for the DBT project
+PROJECT_DIR = "dags/dbt/jaffle_shop"
+
+DBT_IMAGE = "dbt-jaffle-shop:1.0.0"
+
+PROJECT_SEEDS = ["raw_customers", "raw_payments", "raw_orders"]
+with DAG(
+    dag_id="jaffle_shop_docker",
+    start_date=datetime(2022, 11, 27),
+    schedule=None,
+    catchup=False,
+) as dag:
+
+    pre_dbt_workflow = EmptyOperator(task_id="pre_dbt_workflow")
+
+    with TaskGroup(group_id="drop_seeds_if_exist") as drop_seeds:
+        for seed in PROJECT_SEEDS:
+            DbtRunOperationDockerOperator(
+                task_id=f"drop_{seed}_if_exists",
+                macro_name="drop_table",
+                args={"table_name": seed},
+                project_dir=PROJECT_DIR,
+                schema="public",
+                conn_id="postgres_default",
+                image=DBT_IMAGE,
+                network_mode="bridge",
+            )
+
+    create_seed = DbtSeedDockerOperator(
+        task_id="seed",
+        project_dir=PROJECT_DIR,
+        schema="public",
+        conn_id="postgres_default",
+        image=DBT_IMAGE,
+        network_mode="bridge",
+    )
+
+    post_dbt_workflow = EmptyOperator(task_id="post_dbt_workflow")
+
+    pre_dbt_workflow >> drop_seeds >> create_seed >> post_dbt_workflow

--- a/dags/jaffle_shop_kubernetes.py
+++ b/dags/jaffle_shop_kubernetes.py
@@ -1,0 +1,73 @@
+"""
+## Jaffle Shop DAG
+[Jaffle Shop](https://github.com/dbt-labs/jaffle_shop) is a fictional eCommerce store. This dbt project originates from
+dbt labs as an example project with dummy data to demonstrate a working dbt core project. This DAG uses the cosmos dbt
+parser to generate an Airflow TaskGroup from the dbt project folder
+
+"""
+from airflow import DAG
+from airflow.kubernetes.secret import Secret
+from pendulum import datetime
+
+from cosmos.providers.dbt.core.operators.kubernetes import DbtSeedKubernetesOperator, DbtRunKubernetesOperator
+from cosmos.providers.dbt.task_group import DbtTaskGroup
+
+PROJECT_DIR = "dags/dbt/jaffle_shop"
+DBT_IMAGE = "dbt-jaffle-shop:latest"
+
+project_seeds = [
+        {"project": "jaffle_shop", "seeds": [
+            "raw_customers", "raw_payments", "raw_orders"]}
+]
+
+postgres_password_secret = Secret(
+    deploy_type="env",
+    deploy_target="POSTGRES_PASSWORD",
+    secret="postgres-secrets",
+    key="password",
+)
+
+postgres_host_secret = Secret(
+    deploy_type="env",
+    deploy_target="POSTGRES_HOST",
+    secret="postgres-secrets",
+    key="host",
+)
+
+with DAG(
+    dag_id="jaffle_shop_k8s",
+    start_date=datetime(2022, 11, 27),
+    doc_md=__doc__,
+    catchup=False,
+) as dag:
+
+    load_seeds = DbtSeedKubernetesOperator(
+        task_id=f"load_seeds",
+        project_dir=PROJECT_DIR,
+        get_logs=True,
+        schema="public",
+        conn_id="postgres_default",
+        image=DBT_IMAGE,
+        is_delete_operator_pod=False,
+        secrets=[postgres_password_secret, postgres_host_secret]
+    )
+
+    run_models = DbtTaskGroup(
+        group_id="jaffle_shop",
+        dbt_project_name="jaffle_shop",
+        dbt_root_path="./dags/dbt/",
+        conn_id="postgres_default",
+        execution_mode="kubernetes",
+        operator_args={
+            "image": DBT_IMAGE,
+            "get_logs": True,
+            "is_delete_operator_pod": False,
+            "secrets": [postgres_password_secret, postgres_host_secret]
+        },
+        dbt_args={
+            "schema": "public",
+            "project_dir": PROJECT_DIR,
+        }
+    )
+
+    load_seeds >> run_models

--- a/example_postgres_profile.yml
+++ b/example_postgres_profile.yml
@@ -1,0 +1,11 @@
+postgres_profile:
+  outputs:
+    dev:
+      dbname: '{{ env_var(''POSTGRES_DATABASE'') }}'
+      host: '{{ env_var(''POSTGRES_HOST'') }}'
+      pass: '{{ env_var(''POSTGRES_PASSWORD'') }}'
+      port: '{{ env_var(''POSTGRES_PORT'') | as_number }}'
+      schema: '{{ env_var(''POSTGRES_SCHEMA'') }}'
+      type: postgres
+      user: '{{ env_var(''POSTGRES_USER'') }}'
+  target: dev

--- a/postgres_profile_dbt_project.yml
+++ b/postgres_profile_dbt_project.yml
@@ -1,0 +1,26 @@
+name: 'jaffle_shop'
+
+config-version: 2
+version: '0.1'
+
+profile: postgres_profile
+
+model-paths: ["models"]
+seed-paths: ["seeds"]
+test-paths: ["tests"]
+analysis-paths: ["analysis"]
+macro-paths: ["macros"]
+
+target-path: "target"
+clean-targets:
+    - "target"
+    - "dbt_modules"
+    - "logs"
+
+require-dbt-version: [">=1.0.0", "<2.0.0"]
+
+models:
+  jaffle_shop:
+      materialized: table
+      staging:
+        materialized: view


### PR DESCRIPTION
The PR adds the following:
- Examples DAGs to demonstrate usage of DBT Docker and K8S operators
- A Dockerfile that is used to build a DBT project image with an example `postgres` profile that will be supplied as image argument to the Docker and K8S operators
- Supporting files that are needed in the docker image to be built like the `example_postgres_profile.yml` as the Docker image uses a `postgres` connection for the DBT project. The Dockerfile (`Dockerfile.postgres_profile_docker_k8s`) is a reference and users could create a similar docker image based on their project needs.
