### PR TITLE
Round of Maintenance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/astro-runtime:9.6.0
+FROM quay.io/astronomer/astro-runtime:10.0.0
 
 WORKDIR /usr/local/airflow
 COPY dbt-requirements.txt ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,6 @@
 FROM quay.io/astronomer/astro-runtime:9.6.0
+
+WORKDIR /usr/local/airflow
+COPY dbt-requirements.txt ./
+RUN python -m virtualenv dbt_venv && source dbt_venv/bin/activate && \
+    pip install --no-cache-dir -r dbt-requirements.txt && deactivate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,1 @@
-FROM quay.io/astronomer/astro-runtime:7.2.0
-
-# install python virtualenv to run dbt
-WORKDIR /usr/local/airflow
-COPY dbt-requirements.txt ./
-RUN python -m virtualenv dbt_venv && source dbt_venv/bin/activate && \
-    pip install --no-cache-dir -r dbt-requirements.txt && deactivate
+FROM quay.io/astronomer/astro-runtime:9.6.0

--- a/dags/dbt/jaffle_shop/macros/drop_table.sql
+++ b/dags/dbt/jaffle_shop/macros/drop_table.sql
@@ -1,4 +1,4 @@
-{%- macro drop_table(table_name) -%}
+{%- macro drop_table_by_name(table_name) -%}
     {%- set drop_query -%}
         DROP TABLE IF EXISTS {{ target.schema }}.{{ table_name }} CASCADE
     {%- endset -%}

--- a/dags/jaffle_shop.py
+++ b/dags/jaffle_shop.py
@@ -1,8 +1,25 @@
+import os
+from pathlib import Path
+
 from airflow import DAG
 from airflow.operators.empty import EmptyOperator
 from pendulum import datetime
 
-from cosmos.providers.dbt.task_group import DbtTaskGroup
+from cosmos import DbtTaskGroup, ProjectConfig, ProfileConfig, ExecutionConfig
+from cosmos.profiles import PostgresUserPasswordProfileMapping
+
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
+DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+
+profile_config = ProfileConfig(
+    profile_name="default",
+    target_name="dev",
+    profile_mapping=PostgresUserPasswordProfileMapping(
+        conn_id="airflow_db",
+        profile_args={"schema": "public"},
+    )
+)
+
 
 with DAG(
     dag_id="jaffle_shop",
@@ -14,13 +31,14 @@ with DAG(
     pre_dbt_workflow = EmptyOperator(task_id="pre_dbt_workflow")
 
     jaffle_shop = DbtTaskGroup(
-        dbt_root_path="/usr/local/airflow/dags/dbt",
-        dbt_project_name="jaffle_shop",
-        conn_id="airflow_db",
-        dbt_args={
-            "schema": "public",
-            "dbt_executable_path": "/usr/local/airflow/dbt_venv/bin/dbt"
-        },
+        group_id="jaffle_shop",
+        project_config=ProjectConfig(
+            (DBT_ROOT_PATH / "jaffle_shop").as_posix(),
+        ),
+        execution_config=ExecutionConfig(),
+        operator_args={"install_deps": True},
+        profile_config=profile_config,
+        default_args={"retries": 2},
         dag=dag,
     )
 

--- a/dags/jaffle_shop.py
+++ b/dags/jaffle_shop.py
@@ -35,7 +35,8 @@ with DAG(
         project_config=ProjectConfig(
             (DBT_ROOT_PATH / "jaffle_shop").as_posix(),
         ),
-        execution_config=ExecutionConfig(),
+        execution_config=ExecutionConfig(
+            dbt_executable_path="/usr/local/airflow/dbt_venv/bin/dbt"),
         operator_args={"install_deps": True},
         profile_config=profile_config,
         default_args={"retries": 2},

--- a/dags/jaffle_shop_docker.py
+++ b/dags/jaffle_shop_docker.py
@@ -3,8 +3,7 @@ from airflow.operators.empty import EmptyOperator
 from airflow.utils.task_group import TaskGroup
 from pendulum import datetime
 
-from cosmos.providers.dbt.core.operators.docker import DbtRunOperationDockerOperator, DbtSeedDockerOperator
-
+from cosmos.operators.docker import DbtRunOperationDockerOperator, DbtSeedDockerOperator
 
 # PATH within the Docker container for the DBT project
 PROJECT_DIR = "dags/dbt/jaffle_shop"

--- a/dags/jaffle_shop_filtered.py
+++ b/dags/jaffle_shop_filtered.py
@@ -34,7 +34,9 @@ with DAG(
         project_config=ProjectConfig(
             (DBT_ROOT_PATH / "jaffle_shop").as_posix(),
         ),
-        execution_config=ExecutionConfig(),
+        execution_config=ExecutionConfig(
+            dbt_executable_path="/usr/local/airflow/dbt_venv/bin/dbt",
+        ),
         operator_args={"install_deps": True},
         profile_config=profile_config,
         default_args={"retries": 2},

--- a/dags/jaffle_shop_filtered.py
+++ b/dags/jaffle_shop_filtered.py
@@ -1,8 +1,24 @@
+import os
+from pathlib import Path
+
 from airflow import DAG
 from airflow.operators.empty import EmptyOperator
 from pendulum import datetime
 
-from cosmos.providers.dbt.task_group import DbtTaskGroup
+from cosmos import DbtTaskGroup, ProfileConfig, ExecutionConfig, ProjectConfig, RenderConfig
+from cosmos.profiles import PostgresUserPasswordProfileMapping
+
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
+DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+
+profile_config = ProfileConfig(
+    profile_name="default",
+    target_name="dev",
+    profile_mapping=PostgresUserPasswordProfileMapping(
+        conn_id="airflow_db",
+        profile_args={"schema": "public"},
+    ),
+)
 
 with DAG(
     dag_id="jaffle_shop_filtered",
@@ -14,15 +30,18 @@ with DAG(
     pre_dbt_workflow = EmptyOperator(task_id="pre_dbt_workflow")
 
     jaffle_shop = DbtTaskGroup(
-        dbt_root_path="/usr/local/airflow/dags/dbt",
-        dbt_project_name="jaffle_shop",
-        conn_id="airflow_db",
-        dbt_args={
-            "schema": "public",
-            "dbt_executable_path": "/usr/local/airflow/dbt_venv/bin/dbt"
-        },
-        select={"configs": ["tags:customers"]},
+        group_id="customers_group",
+        project_config=ProjectConfig(
+            (DBT_ROOT_PATH / "jaffle_shop").as_posix(),
+        ),
+        execution_config=ExecutionConfig(),
+        operator_args={"install_deps": True},
+        profile_config=profile_config,
+        default_args={"retries": 2},
         dag=dag,
+        render_config=RenderConfig(
+            select=["tag:customers"],
+        )
     )
 
     post_dbt_workflow = EmptyOperator(task_id="post_dbt_workflow")

--- a/dags/jaffle_shop_kubernetes.py
+++ b/dags/jaffle_shop_kubernetes.py
@@ -12,7 +12,7 @@ https://astronomer.github.io/astronomer-cosmos/getting_started/kubernetes.html#k
 from pathlib import Path
 
 from airflow import DAG
-from airflow.kubernetes.secret import Secret
+from airflow.providers.cncf.kubernetes.secret import Secret
 from pendulum import datetime
 
 from cosmos import (
@@ -21,7 +21,6 @@ from cosmos import (
     ExecutionConfig,
     ExecutionMode,
     DbtSeedKubernetesOperator,
-    DbtRunKubernetesOperator,
     DbtTaskGroup,
 )
 from cosmos.profiles import PostgresUserPasswordProfileMapping

--- a/dbt-requirements.txt
+++ b/dbt-requirements.txt
@@ -1,2 +1,0 @@
-dbt-postgres==1.3.1
-pytz

--- a/dbt-requirements.txt
+++ b/dbt-requirements.txt
@@ -1,0 +1,2 @@
+dbt-postgres~=1.7.4
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-astronomer-cosmos
+dbt-postgres~=1.7.4
+astronomer-cosmos[docker]~=1.2.5
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-dbt-postgres~=1.7.4
 astronomer-cosmos[docker]~=1.2.5
-pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-astronomer-cosmos[docker]~=1.2.5
+astronomer-cosmos[docker]~=1.3.0


### PR DESCRIPTION
This PR includes some maintenance tasks that were needed in order to get the DAGs in this repo to work again in the local Astronomer setup. Specifically:
1. Restrict the versions of packages in use to avoid this happening again (part of the problem was that `astronomer-cosmos` was unpinned, leading it to grab the latest version, which then caused compatibility issues with the existing code).
2. Bump versions where appropriate
3. Rework DAGs to use the new `Config` classes (e.g. `RenderConfig`, `ProfileConfig`, `ExecutionConfig`.
4. Remove the virtualenv in the Dockerfile, we can simplify by using the Python environment provided in the Docker container.
5. Fix a bug in the dbt code (see [this commit](https://github.com/astronomer/astronomer-cosmos/pull/516/commits/deb99649ddf7cd656e3b4641f050012dc54f8530#diff-04ddeb3f5adbe4a0b02dc99db61196647086840e023b90ceecdbb4e4ce72988cR1)) that caused failing dbt jobs when the materialization was set to `table`.