### PR TITLE
add GCP Cloud Run Job Execution Mode example

### DIFF
--- a/dags/jaffle_shop_gcp_cloud_run_job.py
+++ b/dags/jaffle_shop_gcp_cloud_run_job.py
@@ -1,0 +1,51 @@
+import os
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from pendulum import datetime
+
+from cosmos import DbtTaskGroup, ProjectConfig, ExecutionConfig
+from cosmos.constants import ExecutionMode
+
+
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
+DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+
+GCP_PROJECT_ID = "<<<<YOUR_GCP_PROJECT_ID>>>>"
+GCP_LOCATION = "<<<<YOUR_GCP_REGION>>>>"
+GCP_CLOUD_RUN_JOB_NAME = "astronomer-cosmos-example"
+
+project_config = ProjectConfig(
+    dbt_project_path=(DBT_ROOT_PATH / "jaffle_shop").as_posix(),
+)
+
+execution_config = ExecutionConfig(
+    execution_mode=ExecutionMode.GCP_CLOUD_RUN_JOB,
+)
+
+with DAG(
+    dag_id="jaffle_shop",
+    start_date=datetime(2022, 11, 27),
+    schedule=None,
+    catchup=False,
+) as dag:
+
+    pre_dbt_workflow = EmptyOperator(task_id="pre_dbt_workflow")
+
+    jaffle_shop = DbtTaskGroup(
+        group_id="jaffle_shop",
+        project_config=project_config,
+        execution_config=execution_config,
+        operator_args={
+            "project_id": GCP_PROJECT_ID,
+            "region": GCP_LOCATION,
+            "job_name": GCP_CLOUD_RUN_JOB_NAME,
+            },
+        default_args={"retries": 2},
+        dag=dag,
+    )
+
+    post_dbt_workflow = EmptyOperator(task_id="post_dbt_workflow")
+
+pre_dbt_workflow >> jaffle_shop >> post_dbt_workflow

--- a/gcp_cloud_run_job_example/Dockerfile.gcp_cloud_run_job
+++ b/gcp_cloud_run_job_example/Dockerfile.gcp_cloud_run_job
@@ -1,0 +1,20 @@
+FROM python:3.11
+
+ENV GCP_PROJECT_ID=<<<<YOUR_GCP_PROJECT_ID>>>>
+ENV GCP_REGION=<<<<YOUR_GCP_REGION>>>>
+ENV BIGQUERY_DATASET=astronomer_cosmos_example
+ENV BIGQUERY_PRIORITY=interactive
+ENV BIGQUERY_THREADS=1
+ENV BIGQUERY_TIMEOUT=300
+ENV BIGQUERY_JOB_RETRIES=1
+ENV GCP_AUTH_METHOD=oauth
+
+RUN pip install dbt-core==1.8.2 dbt-bigquery==1.8.1
+
+RUN mkdir /root/.dbt
+
+COPY dags dags
+COPY gcp_cloud_run_job_example/example_bigquery_profile.yml /root/.dbt/profiles.yml
+COPY gcp_cloud_run_job_example/bigquery_profile_dbt_project.yml dags/dbt/jaffle_shop/dbt_project.yml
+
+WORKDIR /dags/dbt/jaffle_shop

--- a/gcp_cloud_run_job_example/bigquery_profile_dbt_project.yml
+++ b/gcp_cloud_run_job_example/bigquery_profile_dbt_project.yml
@@ -1,0 +1,29 @@
+name: 'jaffle_shop'
+
+config-version: 2
+version: '0.1'
+
+profile: bigquery_profile
+
+model-paths: ["models"]
+seed-paths: ["seeds"]
+test-paths: ["tests"]
+analysis-paths: ["analysis"]
+macro-paths: ["macros"]
+
+target-path: "target"
+clean-targets:
+    - "target"
+    - "dbt_modules"
+    - "logs"
+
+require-dbt-version: [">=1.0.0", "<2.0.0"]
+
+models:
+  +persists_docs:
+    relation: true
+    columns: true
+  jaffle_shop:
+      materialized: table
+      staging:
+        materialized: view

--- a/gcp_cloud_run_job_example/example_bigquery_profile.yml
+++ b/gcp_cloud_run_job_example/example_bigquery_profile.yml
@@ -1,0 +1,13 @@
+bigquery_profile:
+  outputs:
+    dev:
+      type: bigquery
+      dataset: '{{ env_var(''BIGQUERY_DATASET'') }}'
+      project: '{{ env_var(''GCP_PROJECT_ID'') }}'
+      location: '{{ env_var(''GCP_REGION'') }}'
+      priority: '{{ env_var(''BIGQUERY_PRIORITY'') }}'
+      threads: '{{ env_var(''BIGQUERY_THREADS'') | int }}'
+      job_execution_timeout_seconds: '{{ env_var(''BIGQUERY_TIMEOUT'') | int }}'
+      job_retries: '{{ env_var(''BIGQUERY_JOB_RETRIES'') | int }}'
+      method: '{{ env_var(''GCP_AUTH_METHOD'') }}'
+  target: dev


### PR DESCRIPTION
This PR is related to the new GCP Cloud Run Job Execution Mode feature on astronomer-cosmos [issue #1149](https://github.com/astronomer/astronomer-cosmos/issues/1149). 
It provides fully functional example setup for the new feature, includeing ``Dockerfile``, ``dbt profile``, ``dbt project`` and ``DAG``.

The walkthrough can be found at astronomer-cosmos [codebase](https://github.com/astronomer/astronomer-cosmos/blob/main/docs/getting_started/gcp-cloud-run-job.rst) once [PR #1153](https://github.com/astronomer/astronomer-cosmos/pull/1153) has been merged.

Please note that this PR will be functional only when [PR #1153](https://github.com/astronomer/astronomer-cosmos/pull/1153) has been merged.